### PR TITLE
Add GHCR support and release v0.5.6

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -68,6 +68,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Prepare tag
         id: prep
         run: echo "branch=$(echo ${GITHUB_REF##*/} | tr '/' '-')" >> $GITHUB_OUTPUT
@@ -80,5 +86,7 @@ jobs:
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/hello-build-agent:${{ steps.meta.outputs.version }}
             ${{ secrets.DOCKERHUB_USERNAME }}/hello-build-agent:latest
+            ghcr.io/${{ github.repository_owner }}/hello-build-agent:${{ steps.meta.outputs.version }}
+            ghcr.io/${{ github.repository_owner }}/hello-build-agent:latest
           build-args: |
             HBA_VERSION=${{ steps.meta.outputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
+
 All notable changes to this project are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+## v0.5.6 - 2025-06-21
+
+### Added
+
+* Docker image published to GitHub Container Registry (ghcr.io) alongside Docker Hub.
 
 ## v0.5.5 - 2025‑05‑25
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![PyPI](https://img.shields.io/pypi/v/hello-build-agent.svg)](https://pypi.org/project/hello-build-agent)
 [![CI](https://github.com/x0iv/hello-build-agent/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/x0iv/hello-build-agent/actions)
 [![Docker](https://img.shields.io/docker/pulls/x0iv/hello-build-agent)](https://hub.docker.com/r/x0iv/hello-build-agent)
+[![GHCR](https://img.shields.io/badge/ghcr.io%2Fx0iv%2Fhello--build--agent-blue)](https://github.com/x0iv/hello-build-agent/pkgs/container/hello-build-agent)
 
 [Changelog](CHANGELOG.md) • [License](LICENSE)
 
@@ -23,7 +24,7 @@
 | **Qdrant ingestion & search** | README and file-tree chunks are embedded and stored in Qdrant; you can query them later (`query_qdrant`). |
 | **Quota guards**          | Two env-controlled limits: `QUOTA_TOKENS`, `QUOTA_FAILS` ― agent pauses and asks the human before overspending. |
 | **Live Rich logs**        | Timestamp · action · comment · token-counter, neatly aligned and colourised. |
-| **CI/CD ready**           | GitHub Actions → PyPI wheel + Docker Hub image on each `vX.Y.Z` tag. |
+| **CI/CD ready**           | GitHub Actions → PyPI wheel + Docker Hub & GHCR images on each `vX.Y.Z` tag. |
 
 \* Change the model with the `MODEL` env var or `--model` CLI flag.
 


### PR DESCRIPTION
## Summary
- login to GHCR in the CI workflow so images push to Docker Hub and GHCR
- show a GHCR badge in the README and mention images are published to GHCR
- release `v0.5.6` in the changelog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856aaaa92d4832ead1039094f9907ff